### PR TITLE
fix: broken launch on linux

### DIFF
--- a/source/cli.tsx
+++ b/source/cli.tsx
@@ -1,4 +1,5 @@
-#!/usr/bin/env node --no-warnings
+#!/usr/bin/env -S node --no-warnings=ExperimentalWarning
+
 import React from 'react';
 import {render} from 'ink';
 import meow from 'meow';


### PR DESCRIPTION
Adds the -S flag to the shebang, which from my testing makes the script work and display no errors on linux and macOS. 